### PR TITLE
Фикс перенаправления

### DIFF
--- a/UnitFrames.lua
+++ b/UnitFrames.lua
@@ -935,7 +935,7 @@ local function GetOptionsTable_Power(hasDetatchOption, updateFunc, groupName, nu
 				type = "execute",
 				name = L["Coloring"],
 				desc = L["This opens the UnitFrames Color settings. These settings affect all unitframes."],
-				func = function() ACD:SelectGroup("ElvUI", "unitframe", "general", "allColorsGroup", "powerGroup") end,
+				func = function() ACD:SelectGroup("ElvUI", "unitframe", "generalOptionsGroup", "allColorsGroup", "powerGroup") end,
 			},
 			position = {
 				order = 7,


### PR DESCRIPTION
Кнопка "Окрашивание" имела неверное значение что вело в начальное меню а не в параметр окрашивания куда нужно было.